### PR TITLE
Workaround for internal compiler error regarding some native functions.

### DIFF
--- a/openjdk/java/awt/Font.java
+++ b/openjdk/java/awt/Font.java
@@ -821,12 +821,12 @@ public class Font implements java.io.Serializable
     }
 
     private static class FontFamilyReference extends WeakReference<FontFamily> {
-        
+
         private static final ReferenceQueue<FontFamily> fontFamilyQueue = new ReferenceQueue<>();
         private static final Set<FontFamilyReference> refs = Collections.synchronizedSet( new HashSet<FontFamilyReference>() );
         static {
-            sun.misc.SharedSecrets.getJavaLangAccess().registerShutdownHook( 5, // Shutdown hook invocation order 
-            true, // register even if shutdown in progress 
+            sun.misc.SharedSecrets.getJavaLangAccess().registerShutdownHook( 5, // Shutdown hook invocation order
+            true, // register even if shutdown in progress
             new Runnable() {
                 public void run() {
                     for( FontFamilyReference ref : refs ) {
@@ -841,7 +841,7 @@ public class Font implements java.io.Serializable
             super( family, fontFamilyQueue );
             this.fontFile = fontFile;
             refs.add( this );
-            
+
             do {
                 FontFamilyReference ref = (FontFamilyReference)fontFamilyQueue.poll();
                 if( ref == null ) {
@@ -850,13 +850,13 @@ public class Font implements java.io.Serializable
                 ref.delete( true );
             } while(true);
         }
-        
+
         private void delete( boolean isQueue ) {
             FontFamily family = get();
             if( family != null ) {
                 family.Dispose();
             }
-            
+
             if( fontFile.delete() && isQueue) {
                 refs.remove( this );
             }
@@ -926,8 +926,8 @@ public class Font implements java.io.Serializable
             fontFile.delete();
             throw ffe;
         }
-        
-        FontFamily family = pfc.get_Families()[0]; 
+
+        FontFamily family = pfc.get_Families()[0];
         new FontFamilyReference( family, fontFile );
 
         // create the font object
@@ -937,13 +937,15 @@ public class Font implements java.io.Serializable
         return font;
     }
 
-    @DllImportAttribute.Annotation(value="gdi32")
-    private static native int RemoveFontResourceEx(String filename, int fl, IntPtr pdv);    
+    // TODO https://github.com/ikvm-revived/ikvm/issues/1
+    //@DllImportAttribute.Annotation(value="gdi32")
+    //private static native int RemoveFontResourceEx(String filename, int fl, IntPtr pdv);
 
     @cli.System.Security.SecuritySafeCriticalAttribute.Annotation
     private static void RemoveFontResourceEx(String filename) {
         if( ikvm.internal.Util.WINDOWS ) {
-            RemoveFontResourceEx( filename, 16, IntPtr.Zero );
+            //RemoveFontResourceEx( filename, 16, IntPtr.Zero );
+            throw new UnsupportedOperationException("https://github.com/ikvm-revived/ikvm/issues/1");
         }
     }
 

--- a/openjdk/sun/awt/IkvmDataTransferer.java
+++ b/openjdk/sun/awt/IkvmDataTransferer.java
@@ -18,7 +18,7 @@
   3. This notice may not be removed or altered from any source distribution.
 
   Jeroen Frijters
-  jeroen@frijters.net 
+  jeroen@frijters.net
 
  */
 
@@ -58,7 +58,7 @@ public abstract class IkvmDataTransferer extends DataTransferer {
 	public static final long CFSTR_INETURL = RegisterClipboardFormat("UniformResourceLocator");
 	public static final long CF_PNG = RegisterClipboardFormat("PNG");
 	public static final long CF_JFIF = RegisterClipboardFormat("JFIF");
-	
+
     private static final String[] predefinedClipboardNames = {
         "",
         "TEXT",
@@ -91,14 +91,16 @@ public abstract class IkvmDataTransferer extends DataTransferer {
     }
 
     private static final Long L_CF_LOCALE = (Long) predefinedClipboardNameMap.get(predefinedClipboardNames[CF_LOCALE]);
-    
-    @DllImportAttribute.Annotation(value = "user32.dll", EntryPoint = "RegisterClipboardFormat")
-    private native static int _RegisterClipboardFormat(String format);
+
+    // TODO https://github.com/ikvm-revived/ikvm/issues/1
+    //@DllImportAttribute.Annotation(value = "user32.dll", EntryPoint = "RegisterClipboardFormat")
+    //private native static int _RegisterClipboardFormat(String format);
 
     @cli.System.Security.SecuritySafeCriticalAttribute.Annotation
     private static int RegisterClipboardFormat(String format)
     {
-        return _RegisterClipboardFormat(format);
+        //return _RegisterClipboardFormat(format);
+        throw new UnsupportedOperationException("https://github.com/ikvm-revived/ikvm/issues/1");
     }
 
     public SortedMap getFormatsForFlavors(DataFlavor[] flavors, FlavorTable map) {
@@ -165,7 +167,7 @@ public abstract class IkvmDataTransferer extends DataTransferer {
             format = Long.valueOf(RegisterClipboardFormat(str));
         }
         return format;	}
-	
+
 	protected abstract String getClipboardFormatName(long format);
 
     public boolean isImageFormat(long format) {

--- a/openjdk/sun/nio/ch/FileChannelImpl.java
+++ b/openjdk/sun/nio/ch/FileChannelImpl.java
@@ -1032,7 +1032,7 @@ public class FileChannelImpl
             int PAGE_READONLY = 2;
             int PAGE_READWRITE = 4;
             int PAGE_WRITECOPY = 8;
-            
+
             int FILE_MAP_WRITE = 2;
             int FILE_MAP_READ = 4;
             int FILE_MAP_COPY = 1;
@@ -1103,8 +1103,13 @@ public class FileChannelImpl
         return p.ToInt64();
     }
 
-    @DllImportAttribute.Annotation(value="kernel32", SetLastError=true)
-    private static native SafeFileHandle CreateFileMapping(SafeFileHandle hFile, IntPtr lpAttributes, int flProtect, int dwMaximumSizeHigh, int dwMaximumSizeLow, String lpName);
+    // TODO https://github.com/ikvm-revived/ikvm/issues/1
+    //@DllImportAttribute.Annotation(value="kernel32", SetLastError=true)
+    //private static native SafeFileHandle CreateFileMapping(SafeFileHandle hFile, IntPtr lpAttributes, int flProtect, int dwMaximumSizeHigh, int dwMaximumSizeLow, String lpName);
+    private static SafeFileHandle CreateFileMapping(SafeFileHandle hFile, IntPtr lpAttributes, int flProtect, int dwMaximumSizeHigh, int dwMaximumSizeLow, String lpName)
+    {
+        throw new UnsupportedOperationException("https://github.com/ikvm-revived/ikvm/issues/1");
+    }
 
     @DllImportAttribute.Annotation(value="kernel32", SetLastError=true)
     private static native IntPtr MapViewOfFile(SafeFileHandle hFileMapping, int dwDesiredAccess, int dwFileOffsetHigh, int dwFileOffsetLow, IntPtr dwNumberOfBytesToMap);

--- a/openjdk/sun/nio/ch/FileDispatcherImpl.java
+++ b/openjdk/sun/nio/ch/FileDispatcherImpl.java
@@ -298,9 +298,19 @@ class FileDispatcherImpl extends FileDispatcher
         return new FileDescriptor();
     }
 
-    @DllImportAttribute.Annotation(value="kernel32", SetLastError=true)
-    private static native int LockFileEx(SafeFileHandle hFile, int dwFlags, int dwReserved, int nNumberOfBytesToLockLow, int nNumberOfBytesToLockHigh, OVERLAPPED lpOverlapped);
+    // TODO https://github.com/ikvm-revived/ikvm/issues/1
+    //@DllImportAttribute.Annotation(value="kernel32", SetLastError=true)
+    //private static native int LockFileEx(SafeFileHandle hFile, int dwFlags, int dwReserved, int nNumberOfBytesToLockLow, int nNumberOfBytesToLockHigh, OVERLAPPED lpOverlapped);
+    private static int LockFileEx(SafeFileHandle hFile, int dwFlags, int dwReserved, int nNumberOfBytesToLockLow, int nNumberOfBytesToLockHigh, OVERLAPPED lpOverlapped)
+    {
+        throw new UnsupportedOperationException("https://github.com/ikvm-revived/ikvm/issues/1");
+    }
 
-    @DllImportAttribute.Annotation(value="kernel32", SetLastError=true)
-    private static native int UnlockFileEx(SafeFileHandle hFile, int dwReserved, int nNumberOfBytesToUnlockLow, int nNumberOfBytesToUnlockHigh, OVERLAPPED lpOverlapped);
+    // TODO https://github.com/ikvm-revived/ikvm/issues/1
+    //@DllImportAttribute.Annotation(value="kernel32", SetLastError=true)
+    //private static native int UnlockFileEx(SafeFileHandle hFile, int dwReserved, int nNumberOfBytesToUnlockLow, int nNumberOfBytesToUnlockHigh, OVERLAPPED lpOverlapped);
+    private static int UnlockFileEx(SafeFileHandle hFile, int dwReserved, int nNumberOfBytesToUnlockLow, int nNumberOfBytesToUnlockHigh, OVERLAPPED lpOverlapped)
+    {
+        throw new UnsupportedOperationException("https://github.com/ikvm-revived/ikvm/issues/1");
+    }
 }

--- a/openjdk/sun/nio/fs/NetFileSystemProvider.java
+++ b/openjdk/sun/nio/fs/NetFileSystemProvider.java
@@ -752,8 +752,13 @@ final class NetFileSystemProvider extends AbstractFileSystemProvider
         }
     }
 
-    @DllImportAttribute.Annotation(value="kernel32", SetLastError=true)
-    private static native int MoveFileEx(String lpExistingFileName, String lpNewFileName, int dwFlags);
+    // TODO https://github.com/ikvm-revived/ikvm/issues/1
+    //@DllImportAttribute.Annotation(value="kernel32", SetLastError=true)
+    //private static native int MoveFileEx(String lpExistingFileName, String lpNewFileName, int dwFlags);
+    private static int MoveFileEx(String lpExistingFileName, String lpNewFileName, int dwFlags)
+    {
+        throw new UnsupportedOperationException("https://github.com/ikvm-revived/ikvm/issues/1");
+    }
 
     public boolean isSameFile(Path path, Path path2) throws IOException
     {


### PR DESCRIPTION
The function commented in this commit led errors like the following during compiling a Release-version of some UWP-app already:

> ICE: trying to add a local var with the same name, but different types. during [_RegisterClipboardFormat]

The CN1-fork simply commented those functions as well, so I followed that approach for now. The important thing is that I really only commented those functions which triggered the error until that error didn't occur anymore. So I did not simply commented all native functions by purpose, because currently it seems that some trigger that error, while some don't.

The problem is that currently another error is triggered during compilation, so I can't be sure if that is fixed somehow, the error of this commit happens again with the other functions not yet commented. Because of the second error, committing the current changes seems the best way to go to keep things independent.

This is related to https://github.com/ikvm-revived/ikvm/issues/1.