### PR TITLE
Workaround for code generating multiple `__value`-args.

### DIFF
--- a/openjdk/sun/nio/ch/FileChannelImpl.java
+++ b/openjdk/sun/nio/ch/FileChannelImpl.java
@@ -1032,7 +1032,7 @@ public class FileChannelImpl
             int PAGE_READONLY = 2;
             int PAGE_READWRITE = 4;
             int PAGE_WRITECOPY = 8;
-            
+
             int FILE_MAP_WRITE = 2;
             int FILE_MAP_READ = 4;
             int FILE_MAP_COPY = 1;
@@ -1106,31 +1106,31 @@ public class FileChannelImpl
     @DllImportAttribute.Annotation(value="kernel32", SetLastError=true)
     private static native SafeFileHandle CreateFileMapping(SafeFileHandle hFile, IntPtr lpAttributes, int flProtect, int dwMaximumSizeHigh, int dwMaximumSizeLow, String lpName);
 
-    // TODO https://github.com/ikvm-revived/ikvm/issues/2
+    // TODO https://github.com/ikvm-revived/ikvm/issues/3
     //@DllImportAttribute.Annotation(value="kernel32", SetLastError=true)
     //private static native IntPtr MapViewOfFile(SafeFileHandle hFileMapping, int dwDesiredAccess, int dwFileOffsetHigh, int dwFileOffsetLow, IntPtr dwNumberOfBytesToMap);
     private static IntPtr MapViewOfFile(SafeFileHandle hFileMapping, int dwDesiredAccess, int dwFileOffsetHigh, int dwFileOffsetLow, IntPtr dwNumberOfBytesToMap)
     {
-        throw new UnsupportedOperationException("https://github.com/ikvm-revived/ikvm/issues/2");
+        throw new UnsupportedOperationException("https://github.com/ikvm-revived/ikvm/issues/3");
     }
 
     @DllImportAttribute.Annotation("kernel32")
     private static native int UnmapViewOfFile(IntPtr lpBaseAddress);
 
-    // TODO https://github.com/ikvm-revived/ikvm/issues/2
+    // TODO https://github.com/ikvm-revived/ikvm/issues/3
     //@DllImportAttribute.Annotation("ikvm-native")
     //private static native int ikvm_munmap(IntPtr address, int size);
     private static int ikvm_munmap(IntPtr address, int size)
     {
-        throw new UnsupportedOperationException("https://github.com/ikvm-revived/ikvm/issues/2");
+        throw new UnsupportedOperationException("https://github.com/ikvm-revived/ikvm/issues/3");
     }
 
-    // TODO https://github.com/ikvm-revived/ikvm/issues/2
+    // TODO https://github.com/ikvm-revived/ikvm/issues/3
     //@DllImportAttribute.Annotation("ikvm-native")
     //private static native IntPtr ikvm_mmap(SafeFileHandle handle, byte writeable, byte copy_on_write, long position, int size);
     private static IntPtr ikvm_mmap(SafeFileHandle handle, byte writeable, byte copy_on_write, long position, int size)
     {
-        throw new UnsupportedOperationException("https://github.com/ikvm-revived/ikvm/issues/2");
+        throw new UnsupportedOperationException("https://github.com/ikvm-revived/ikvm/issues/3");
     }
 
     // Removes an existing mapping

--- a/openjdk/sun/nio/ch/FileChannelImpl.java
+++ b/openjdk/sun/nio/ch/FileChannelImpl.java
@@ -1106,17 +1106,32 @@ public class FileChannelImpl
     @DllImportAttribute.Annotation(value="kernel32", SetLastError=true)
     private static native SafeFileHandle CreateFileMapping(SafeFileHandle hFile, IntPtr lpAttributes, int flProtect, int dwMaximumSizeHigh, int dwMaximumSizeLow, String lpName);
 
-    @DllImportAttribute.Annotation(value="kernel32", SetLastError=true)
-    private static native IntPtr MapViewOfFile(SafeFileHandle hFileMapping, int dwDesiredAccess, int dwFileOffsetHigh, int dwFileOffsetLow, IntPtr dwNumberOfBytesToMap);
+    // TODO https://github.com/ikvm-revived/ikvm/issues/2
+    //@DllImportAttribute.Annotation(value="kernel32", SetLastError=true)
+    //private static native IntPtr MapViewOfFile(SafeFileHandle hFileMapping, int dwDesiredAccess, int dwFileOffsetHigh, int dwFileOffsetLow, IntPtr dwNumberOfBytesToMap);
+    private static IntPtr MapViewOfFile(SafeFileHandle hFileMapping, int dwDesiredAccess, int dwFileOffsetHigh, int dwFileOffsetLow, IntPtr dwNumberOfBytesToMap)
+    {
+        throw new UnsupportedOperationException("https://github.com/ikvm-revived/ikvm/issues/2");
+    }
 
     @DllImportAttribute.Annotation("kernel32")
     private static native int UnmapViewOfFile(IntPtr lpBaseAddress);
 
-    @DllImportAttribute.Annotation("ikvm-native")
-    private static native int ikvm_munmap(IntPtr address, int size);
+    // TODO https://github.com/ikvm-revived/ikvm/issues/2
+    //@DllImportAttribute.Annotation("ikvm-native")
+    //private static native int ikvm_munmap(IntPtr address, int size);
+    private static int ikvm_munmap(IntPtr address, int size)
+    {
+        throw new UnsupportedOperationException("https://github.com/ikvm-revived/ikvm/issues/2");
+    }
 
-    @DllImportAttribute.Annotation("ikvm-native")
-    private static native IntPtr ikvm_mmap(SafeFileHandle handle, byte writeable, byte copy_on_write, long position, int size);
+    // TODO https://github.com/ikvm-revived/ikvm/issues/2
+    //@DllImportAttribute.Annotation("ikvm-native")
+    //private static native IntPtr ikvm_mmap(SafeFileHandle handle, byte writeable, byte copy_on_write, long position, int size);
+    private static IntPtr ikvm_mmap(SafeFileHandle handle, byte writeable, byte copy_on_write, long position, int size)
+    {
+        throw new UnsupportedOperationException("https://github.com/ikvm-revived/ikvm/issues/2");
+    }
 
     // Removes an existing mapping
     @cli.System.Security.SecuritySafeCriticalAttribute.Annotation


### PR DESCRIPTION
The functions commented in this commit led to errors like the following during compiling a Release-version of some UWP-app:

> error CS0100: The parameter name '__value' is a duplicate"

The CN1-fork simply commented those functions as well, so I followed that approach for now. The important thing is that I really only commented those functions which triggered the error until that error didn't occur anymore. So I did not simply commented all native functions by purpose, because currently it seems that some trigger that error, while some don't. The difference most likely simply is the number of arguments, because one "__value" is not a problem, while two are.

This is related to https://github.com/ikvm-revived/ikvm/issues/3.