### PR TITLE
Fix ikvm-build-2 for strong naming

### DIFF
--- a/reflect/StrongNameKeyPair.cs
+++ b/reflect/StrongNameKeyPair.cs
@@ -201,12 +201,12 @@ namespace IKVM.Reflection
 				// Read Modulus
 				byte[] modulus = br.ReadBytes(
 					(int)keyBitLength / 8);
-				// Read Private Key Paremeters
 				Array.Reverse(modulus);
 				rsaParameters.Modulus = modulus;
 
 				if (keyType == 7)
 				{
+					// Read Private Key Parameters
 					byte[] prime1 = br.ReadBytes(
 						(int)keyBitLength / 16);
 					byte[] prime2 = br.ReadBytes(


### PR DESCRIPTION
## Updates

- ImportCspBlob caused an exception "KeySet not found" when trying to sign the hash.  This update replaces the usage of ImportCspBlob and ExportCspBlob calls on the RSACryptoServiceProvider with importing and exporting RSAParameters instead.
- Helper functions to transform SNK byte array to RSAParameters, and also to ExportPublicKey byte array from RSAParameters.
- `build.core.cmd` now completes, and with the resulting binaries, I was able to cross-compile a java jar and sign it with a different snk key and run the resulting DLLs under .NET 6

## Problems
- Has the following warning, but unsure if this is safe to ignore
`EXEC : warning : assembly "IKVM.OpenJDK.Core.dll" is ignored as previously loaded assembly "IKVM.OpenJDK.Core.dll" has the same identity "IKVM.OpenJDK.Core, Version=8.5.0.3, Culture=neutral, PublicKeyToken=13235d27fcbfff58" [\ikvm\openjdk\openjdk.csproj]
EXEC : warning : Running ikvmstub on ikvmc compiled assemblies is not supported. [\ikvm\openjdk\openjdk.csproj]` 