### PR TITLE
Build fixes for build.framework.cmd

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
-    <LangVersion>8.0</LangVersion>
+    <!-- IMPORTANT: CAS is only supported on .NET Framework when using LangVersion 7.0 or prior
+         https://docs.microsoft.com/en-us/previous-versions/dotnet/framework/code-access-security/using-libraries-from-partially-trusted-code -->
+    <LangVersion>7.0</LangVersion>
     <NoWarn>$(NoWarn);1591;1573</NoWarn>
   </PropertyGroup>
   

--- a/openjdk/openjdk.targets
+++ b/openjdk/openjdk.targets
@@ -146,7 +146,9 @@
   <Target Name="AssemblyInfoJava">
     <PropertyGroup>
       <IKVMRuntime>IKVM.Runtime</IKVMRuntime>
+      <IKVMRuntime Condition=" '$(SignAssembly)' == 'true' And '$(PublicKey)' != '' ">$(IKVMRuntime), PublicKey=$(PublicKey)</IKVMRuntime>
       <IKVMAWTWinForms>IKVM.AWT.WinForms</IKVMAWTWinForms>
+      <IKVMAWTWinForms Condition=" '$(SignAssembly)' == 'true' And '$(PublicKey)' != '' ">$(IKVMAWTWinForms), PublicKey=$(PublicKey)</IKVMAWTWinForms>
       <Copyright>Copyright</Copyright>
     </PropertyGroup>
     <Copy SourceFiles="AssemblyInfo.java.in" DestinationFiles="AssemblyInfo.java" />


### PR DESCRIPTION
This contains 2 fixes

1. Added the PublicKey to InternalsVisibleTo attributes in `openjdk.targets`
2. Changed `<LangVersion>` to 7.0, which is the last C# version supported by Code Access Security: https://docs.microsoft.com/en-us/previous-versions/dotnet/framework/code-access-security/using-libraries-from-partially-trusted-code