### PR TITLE
Removed support for partial trust (it is obsolete, anyway)

### DIFF
--- a/awt/IKVM.AWT.WinForms.FirstPass/IKVM.AWT.WinForms.FirstPass.csproj
+++ b/awt/IKVM.AWT.WinForms.FirstPass/IKVM.AWT.WinForms.FirstPass.csproj
@@ -38,11 +38,4 @@
     <InternalsVisibleTo Include="IKVM.OpenJDK.SwingAWT" />
   </ItemGroup>
 
-  <Target Name="AddAllowPartiallyTrustedCallers" BeforeTargets="Build">
-    <!-- Handle AllowPartiallyTrustedCallers (.NET Framework only) -->
-    <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-      <AssemblyAttribute Include="System.Security.AllowPartiallyTrustedCallers" />
-    </ItemGroup>
-  </Target>
-
 </Project>

--- a/awt/IKVM.AWT.WinForms/IKVM.AWT.WinForms.csproj
+++ b/awt/IKVM.AWT.WinForms/IKVM.AWT.WinForms.csproj
@@ -56,11 +56,4 @@
     <InternalsVisibleTo Include="IKVM.OpenJDK.SwingAWT" />
   </ItemGroup>
 
-  <Target Name="AddAllowPartiallyTrustedCallers" BeforeTargets="Build">
-    <!-- Handle AllowPartiallyTrustedCallers (.NET Framework only) -->
-    <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-      <AssemblyAttribute Include="System.Security.AllowPartiallyTrustedCallers" />
-    </ItemGroup>
-  </Target>
-
 </Project>

--- a/build.framework.cmd
+++ b/build.framework.cmd
@@ -1,20 +1,30 @@
 @echo off
 
-dotnet build -f net461 tools\updbaseaddresses\updbaseaddresses.csproj
-dotnet build -f net461 tools\depcheck\depcheck.csproj
-dotnet build -f net461 tools\pubkey\pubkey.csproj
-dotnet build -f net461 tools\SourceLicenseAnalyzer\SourceLicenseAnalyzer.csproj
-dotnet build -f net461 reflect\IKVM.Reflection.csproj
-dotnet build -f net461 ikvmstub\ikvmstub.csproj
-dotnet build -f net461 runtime\DummyLibrary\DummyLibrary.csproj
-dotnet build -f net461 runtime\IKVM.Runtime.FirstPass\IKVM.Runtime.FirstPass.csproj
-dotnet build -f net461 awt\IKVM.AWT.WinForms.FirstPass\IKVM.AWT.WinForms.FirstPass.csproj
-dotnet build -f net461 ikvmc\ikvmc.csproj
-dotnet build -f net461 openjdk\openjdk.csproj
-dotnet build -f net461 runtime\IKVM.Runtime.JNI\IKVM.Runtime.JNI.csproj
-dotnet build -f net461 runtime\IKVM.Runtime\IKVM.Runtime.csproj
-dotnet build -f net461 openjdk\openjdk.tools.csproj
-dotnet build -f net461 awt\IKVM.AWT.WinForms\IKVM.AWT.WinForms.csproj
-dotnet build -f net461 tools\implib\implib.csproj
-dotnet build -f net461 ikvm\ikvm.csproj
-dotnet build -f net461 jvm\jvm.csproj
+set CONFIGURATION=Release
+set TARGETFRAMEWORK=net461
+
+set BUILDFLAGS=--nologo --no-dependencies -c %CONFIGURATION% -f %TARGETFRAMEWORK%
+
+dotnet build %BUILDFLAGS% tools\updbaseaddresses\updbaseaddresses.csproj
+dotnet build %BUILDFLAGS% tools\depcheck\depcheck.csproj
+dotnet build %BUILDFLAGS% tools\pubkey\pubkey.csproj
+dotnet build %BUILDFLAGS% tools\SourceLicenseAnalyzer\SourceLicenseAnalyzer.csproj
+dotnet build %BUILDFLAGS% reflect\IKVM.Reflection.csproj
+dotnet build %BUILDFLAGS% ikvmstub\ikvmstub.csproj
+dotnet build %BUILDFLAGS% runtime\DummyLibrary\DummyLibrary.csproj
+dotnet build %BUILDFLAGS% runtime\IKVM.Runtime.FirstPass\IKVM.Runtime.FirstPass.csproj
+dotnet build %BUILDFLAGS% awt\IKVM.AWT.WinForms.FirstPass\IKVM.AWT.WinForms.FirstPass.csproj
+dotnet build %BUILDFLAGS% ikvmc\ikvmc.csproj
+dotnet build %BUILDFLAGS% openjdk\openjdk.csproj
+dotnet build %BUILDFLAGS% runtime\IKVM.Runtime.JNI\IKVM.Runtime.JNI.csproj
+
+rem Remove first-pass runtime binaries.
+del /F /Q bin\%CONFIGURATION%\%TARGETFRAMEWORK%\IKVM.Runtime.dll bin\%CONFIGURATION%\%TARGETFRAMEWORK%\IKVM.Runtime.deps.json bin\%CONFIGURATION%\%TARGETFRAMEWORK%\IKVM.Runtime.xml bin\%CONFIGURATION%\%TARGETFRAMEWORK%\IKVM.Runtime.pdb
+dotnet build %BUILDFLAGS% runtime\IKVM.Runtime\IKVM.Runtime.csproj
+dotnet build %BUILDFLAGS% openjdk\openjdk.tools.csproj
+rem Remove first-pass awt binaries.
+del /F /Q bin\%CONFIGURATION%\%TARGETFRAMEWORK%\IKVM.AWT.WinForms.*
+dotnet build %BUILDFLAGS% awt\IKVM.AWT.WinForms\IKVM.AWT.WinForms.csproj
+dotnet build %BUILDFLAGS% tools\implib\implib.csproj
+dotnet build %BUILDFLAGS% ikvm\ikvm.csproj
+dotnet build %BUILDFLAGS% jvm\jvm.csproj

--- a/ikvmc/ikvmc.csproj
+++ b/ikvmc/ikvmc.csproj
@@ -64,11 +64,4 @@
     <InternalsVisibleTo Include="IKVM.Runtime.JNI" />
   </ItemGroup>
 
-  <Target Name="AddAllowPartiallyTrustedCallers" BeforeTargets="Build">
-    <!-- Handle AllowPartiallyTrustedCallers (.NET Framework only) -->
-    <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-      <AssemblyAttribute Include="System.Security.AllowPartiallyTrustedCallers" />
-    </ItemGroup>
-  </Target>
-
 </Project>

--- a/ikvmstub/ikvmstub.cs
+++ b/ikvmstub/ikvmstub.cs
@@ -193,8 +193,8 @@ static class NetExp
 			else
 			{
 				StaticCompiler.LoadFile(typeof(NetExp).Assembly.Location);
-				StaticCompiler.runtimeAssembly = StaticCompiler.LoadFile(Path.Combine(typeof(NetExp).Assembly.Location, "../IKVM.Runtime.dll"));
-				JVM.CoreAssembly = StaticCompiler.LoadFile(Path.Combine(typeof(NetExp).Assembly.Location, "../IKVM.OpenJDK.Core.dll"));
+				StaticCompiler.runtimeAssembly = StaticCompiler.LoadFile(Path.GetFullPath(Path.Combine(typeof(NetExp).Assembly.Location, "../IKVM.Runtime.dll")));
+				JVM.CoreAssembly = StaticCompiler.LoadFile(Path.GetFullPath(Path.Combine(typeof(NetExp).Assembly.Location, "../IKVM.OpenJDK.Core.dll")));
 			}
 			if (AttributeHelper.IsJavaModule(assembly.ManifestModule))
 			{

--- a/openjdk/AssemblyInfo.java.in
+++ b/openjdk/AssemblyInfo.java.in
@@ -37,7 +37,8 @@
     @cli.System.Runtime.CompilerServices.InternalsVisibleToAttribute.Annotation("@AWTWINFORMS@")
 })
 
-@cli.System.Security.AllowPartiallyTrustedCallersAttribute.Annotation
+// ikvm-revived: Partial trust is obsolete, so we aren't supporting it
+//@cli.System.Security.AllowPartiallyTrustedCallersAttribute.Annotation
 
 // type to collect Assembly attributes applicable to all core library assemblies
 interface commonAttributes {}

--- a/runtime/IKVM.Runtime.FirstPass/IKVM.Runtime.FirstPass.csproj
+++ b/runtime/IKVM.Runtime.FirstPass/IKVM.Runtime.FirstPass.csproj
@@ -54,13 +54,6 @@
     <InternalsVisibleTo Include="IKVM.Runtime.JNI" />
   </ItemGroup>
 
-  <Target Name="AddAllowPartiallyTrustedCallers" BeforeTargets="Build">
-    <!-- Handle AllowPartiallyTrustedCallers (.NET Framework only) -->
-    <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-      <AssemblyAttribute Include="System.Security.AllowPartiallyTrustedCallers" />
-    </ItemGroup>
-  </Target>
-
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <IkvmStub>..\..\bin\$(Configuration)\$(TargetFramework)\ikvmstub.exe</IkvmStub>
   </PropertyGroup>

--- a/runtime/IKVM.Runtime/CodeEmitter.cs
+++ b/runtime/IKVM.Runtime/CodeEmitter.cs
@@ -114,7 +114,9 @@ namespace IKVM.Internal
 #endif
 		private IKVM.Attributes.LineNumberTableAttribute.LineNumberWriter linenums;
 		private CodeEmitterLocal[] tempLocals = new CodeEmitterLocal[32];
+#if NETFRAMEWORK
 		private ISymbolDocumentWriter symbols;
+#endif
 		private List<OpCodeWrapper> code = new List<OpCodeWrapper>(10);
 		private readonly Type declaringType;
 #if LABELCHECK
@@ -2695,10 +2697,12 @@ namespace IKVM.Internal
 
 		internal void SetLineNumber(ushort line)
 		{
+#if NETFRAMEWORK
 			if (symbols != null)
 			{
 				EmitPseudoOpCode(CodeType.SequencePoint, (int)line);
 			}
+#endif
 			EmitPseudoOpCode(CodeType.LineNumber, (int)line);
 		}
 

--- a/runtime/IKVM.Runtime/DynamicTypeWrapper.cs
+++ b/runtime/IKVM.Runtime/DynamicTypeWrapper.cs
@@ -5717,9 +5717,9 @@ namespace IKVM.Internal
 
 			private static class BakedTypeCleanupHack
 			{
-#if NET_4_0 || STATIC_COMPILER
+#if NET40_OR_GREATER || NETSTANDARD || NETCOREAPP || STATIC_COMPILER
 				internal static void Process(DynamicTypeWrapper wrapper) { }
-#else
+#elif NET20_OR_GREATER
 				private static readonly FieldInfo m_methodBuilder = typeof(ConstructorBuilder).GetField("m_methodBuilder", BindingFlags.Instance | BindingFlags.NonPublic);
 				private static readonly FieldInfo[] methodBuilderFields = GetFieldList(typeof(MethodBuilder), new string[]
 					{

--- a/runtime/IKVM.Runtime/IKVM.Runtime.csproj
+++ b/runtime/IKVM.Runtime/IKVM.Runtime.csproj
@@ -71,11 +71,4 @@
     <InternalsVisibleTo Include="IKVM.Runtime.JNI" />
   </ItemGroup>
 
-  <Target Name="AddAllowPartiallyTrustedCallers" BeforeTargets="Build">
-    <!-- Handle AllowPartiallyTrustedCallers (.NET Framework only) -->
-    <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
-      <AssemblyAttribute Include="System.Security.AllowPartiallyTrustedCallers" />
-    </ItemGroup>
-  </Target>
-
 </Project>

--- a/runtime/IKVM.Runtime/openjdk/java.io.cs
+++ b/runtime/IKVM.Runtime/openjdk/java.io.cs
@@ -1102,14 +1102,22 @@ static class Java_java_io_WinNTFileSystem
 		return ok;
 	}
 
+	/// <summary>
+	/// The .NET ticks representing January 1, 1970 0:00:00, also known as the "epoch".
+	/// </summary>
+	private const long UnixEpochTicks = 621355968000000000L;
+
+	private const long UnixEpochMilliseconds = UnixEpochTicks / TimeSpan.TicksPerMillisecond; // 62,135,596,800,000
+
 	private static long DateTimeToJavaLongTime(DateTime datetime)
 	{
-		return (TimeZone.CurrentTimeZone.ToUniversalTime(datetime) - new DateTime(1970, 1, 1)).Ticks / 10000L;
+		long milliseconds = datetime.ToUniversalTime().Ticks / TimeSpan.TicksPerMillisecond;
+		return milliseconds - UnixEpochMilliseconds;
 	}
 
 	private static DateTime JavaLongTimeToDateTime(long datetime)
 	{
-		return TimeZone.CurrentTimeZone.ToLocalTime(new DateTime(new DateTime(1970, 1, 1).Ticks + datetime * 10000L));
+		return DateTimeOffset.FromUnixTimeMilliseconds(datetime).LocalDateTime;
 	}
 
 	public static long getLastModifiedTime(object _this, java.io.File f)

--- a/runtime/IKVM.Runtime/openjdk/java.util.cs
+++ b/runtime/IKVM.Runtime/openjdk/java.util.cs
@@ -27,7 +27,7 @@ static class Java_java_util_TimeZone
 {
 	private static string GetCurrentTimeZoneID()
 	{
-#if NET_4_0
+#if NET40_OR_GREATER || NETCOREAPP || NETSTANDARD
 		return TimeZoneInfo.Local.Id;
 #else
 		// we don't want a static dependency on System.Core (to be able to run on .NET 2.0)
@@ -323,7 +323,7 @@ static class Java_java_util_TimeZone
 
 	public static string getSystemGMTOffsetID()
 	{
-		TimeSpan sp = TimeZone.CurrentTimeZone.GetUtcOffset(DateTime.Now);
+		TimeSpan sp = TimeZoneInfo.Local.GetUtcOffset(DateTime.Now);
 		int hours = sp.Hours;
 		int mins = sp.Minutes;
 		if (hours >= 0 && mins >= 0)


### PR DESCRIPTION
https://github.com/ikvm-revived/ikvm/commit/e7b9870ce874d348f563130fa3f2d9a3b07da75e removes support for partial trust. This is complexity that we don't really need, as it is obsolete, anyway. However, if anyone disagrees, they are welcome to revert the commit and fix the problems we are having with it on .NET Framework.

This PR also fixes several build warnings with both .NET Framework and .NET Core. Some of the hacks that only applied to .NET Framework 3.5 have been conditionally compiled out of the .NET Core binaries.

This also updates `build.framework.cmd` to build a Release rather than a Debug build.