### PR TITLE
RollForward strategy for ikvmc

### DIFF
--- a/ikvmc/ikvmc.csproj
+++ b/ikvmc/ikvmc.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <RollForward>LatestMajor</RollForward>
     <DefineConstants>$(DefineConstants);STATIC_COMPILER;EMITTERS</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <OutputPath>..\bin\$(Configuration)</OutputPath>


### PR DESCRIPTION
@NightOwl888 I believe that with this line we will be able to run `ikvmc.exe` compiled for `netcoreapp3.1` target on machines with `net6.0` without installing `.NET 3.1` runtime. (as we do here https://github.com/sergey-tihon/OpenNLP.NET/pull/14/)

Here you can find official docs
https://docs.microsoft.com/en-us/dotnet/core/versions/selection#framework-dependent-apps-roll-forward

We already use this feature in other tools for the same scenario. Example https://github.com/fsprojects/FsLexYacc/blob/master/src/FsLex/fslex.fsproj#L5-L6