### PR TITLE
ci: publish github releases

### DIFF
--- a/.github/workflows/IKVM.yml
+++ b/.github/workflows/IKVM.yml
@@ -338,7 +338,6 @@ jobs:
       with:
         tag: ${{ steps.GitVersion.outputs.semVer }}
         artifacts: build/bin/*.zip,build/nuget/*.nupkg,build/nuget/*.snupkg,build/tools/*.zip
-        draft: true
         generateReleaseNotes: true
         prerelease: ${{ github.ref == 'refs/heads/develop' }}
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently the github releases will be generated as draft, so the nuget packages and the sdk are out of sync