### PR TITLE
Remove SaveDebugImage

### DIFF
--- a/src/IKVM.Runtime/DynamicClassLoader.cs
+++ b/src/IKVM.Runtime/DynamicClassLoader.cs
@@ -115,20 +115,6 @@ namespace IKVM.Internal
             this.moduleBuilder = moduleBuilder;
             this.hasInternalAccess = hasInternalAccess;
 
-#if !STATIC_COMPILER
-            if (JVM.IsSaveDebugImage)
-            {
-                if (saveClassLoaders == null)
-                {
-                    System.Threading.Interlocked.CompareExchange(ref saveClassLoaders, new List<DynamicClassLoader>(), null);
-                }
-                lock (saveClassLoaders)
-                {
-                    saveClassLoaders.Add(this);
-                }
-            }
-#endif
-
 #if STATIC_COMPILER || CLASSGC
             // Ref.Emit doesn't like the "<Module>" name for types
             // (since it already defines a pseudo-type named <Module> for global methods and fields)
@@ -431,33 +417,6 @@ namespace IKVM.Internal
         }
 
 #if !STATIC_COMPILER
-        internal static void SaveDebugImages()
-        {
-            Console.Error.WriteLine("Saving dynamic assemblies...");
-            JVM.FinishingForDebugSave = true;
-            if (saveClassLoaders != null)
-            {
-                foreach (DynamicClassLoader instance in saveClassLoaders)
-                {
-                    instance.FinishAll();
-                    AssemblyBuilder ab = (AssemblyBuilder)instance.ModuleBuilder.Assembly;
-                    SaveDebugAssembly(ab);
-                }
-            }
-            if (jniProxyAssemblyBuilder != null)
-            {
-                SaveDebugAssembly(jniProxyAssemblyBuilder);
-            }
-            Console.Error.WriteLine("Saving done.");
-        }
-
-        private static void SaveDebugAssembly(AssemblyBuilder ab)
-        {
-            Console.Error.WriteLine("Saving '{0}'", ab.GetName().Name + ".dll");
-#if NETFRAMEWORK
-            ab.Save(ab.GetName().Name + ".dll");
-#endif
-        }
 
         internal static ModuleBuilder CreateJniProxyModuleBuilder()
         {
@@ -550,20 +509,12 @@ namespace IKVM.Internal
             private ForgedKeyPair(byte[] publicKey)
                 : base(ToInfo(publicKey), new StreamingContext())
             {
+
             }
 
             private static SerializationInfo ToInfo(byte[] publicKey)
             {
                 byte[] privateKey = publicKey;
-                if (JVM.IsSaveDebugImage)
-                {
-                    CspParameters cspParams = new CspParameters();
-                    cspParams.KeyContainerName = null;
-                    cspParams.Flags = CspProviderFlags.UseArchivableKey;
-                    cspParams.KeyNumber = 2;
-                    RSACryptoServiceProvider rsa = new RSACryptoServiceProvider(1024, cspParams);
-                    privateKey = rsa.ExportCspBlob(true);
-                }
                 SerializationInfo info = new SerializationInfo(typeof(StrongNameKeyPair), new FormatterConverter());
                 info.AddValue("_keyPairExported", true);
                 info.AddValue("_keyPairArray", privateKey);
@@ -594,27 +545,12 @@ namespace IKVM.Internal
             DateTime now = DateTime.Now;
             name.Version = new Version(now.Year, (now.Month * 100) + now.Day, (now.Hour * 100) + now.Minute, (now.Second * 1000) + now.Millisecond);
             List<CustomAttributeBuilder> attribs = new List<CustomAttributeBuilder>();
-            AssemblyBuilderAccess access;
-            if (JVM.IsSaveDebugImage)
-            {
-#if NETFRAMEWORK
-                access = AssemblyBuilderAccess.RunAndSave;
-#else
-                access = AssemblyBuilderAccess.Run;
-#endif
-            }
+            AssemblyBuilderAccess access = AssemblyBuilderAccess.Run;
+
 #if CLASSGC
-            else if (JVM.classUnloading
-                // DefineDynamicAssembly(..., RunAndCollect, ...) does a demand for PermissionSet(Unrestricted), so we want to avoid that in partial trust scenarios
-                && AppDomain.CurrentDomain.IsFullyTrusted)
-            {
+            if (JVM.classUnloading && AppDomain.CurrentDomain.IsFullyTrusted)
                 access = AssemblyBuilderAccess.RunAndCollect;
-            }
 #endif
-            else
-            {
-                access = AssemblyBuilderAccess.Run;
-            }
 
 #if NETFRAMEWORK
 
@@ -629,7 +565,7 @@ namespace IKVM.Internal
             CustomAttributeBuilder debugAttr = new CustomAttributeBuilder(typeof(DebuggableAttribute).GetConstructor(new Type[] { typeof(bool), typeof(bool) }), new object[] { true, debug });
             assemblyBuilder.SetCustomAttribute(debugAttr);
 #if NETFRAMEWORK
-            ModuleBuilder moduleBuilder = JVM.IsSaveDebugImage ? assemblyBuilder.DefineDynamicModule(name.Name, name.Name + ".dll", debug) : assemblyBuilder.DefineDynamicModule(name.Name, debug);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule(name.Name, debug);
 #else
             ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule(name.Name);
 #endif
@@ -645,6 +581,9 @@ namespace IKVM.Internal
             return AssemblyBuilder.DefineDynamicAssembly(name, access, assemblyAttributes);
 #endif
         }
-#endif // !STATIC_COMPILER
+
+#endif
+
     }
+
 }

--- a/src/IKVM.Runtime/DynamicClassLoader.cs
+++ b/src/IKVM.Runtime/DynamicClassLoader.cs
@@ -58,8 +58,6 @@ namespace IKVM.Internal
 
 #if !STATIC_COMPILER
         static AssemblyBuilder jniProxyAssemblyBuilder;
-        static List<DynamicClassLoader> saveClassLoaders;
-        static int dumpCounter;
 #endif
 
 #if STATIC_COMPILER || CLASSGC
@@ -422,23 +420,13 @@ namespace IKVM.Internal
         {
             AssemblyName name = new AssemblyName();
             name.Name = "jniproxy";
-#if NETFRAMEWORK
-            jniProxyAssemblyBuilder = DefineDynamicAssembly(name, AssemblyBuilderAccess.RunAndSave, null);
-            return jniProxyAssemblyBuilder.DefineDynamicModule("jniproxy.dll", "jniproxy.dll");
-#else
             jniProxyAssemblyBuilder = DefineDynamicAssembly(name, AssemblyBuilderAccess.Run, null);
             return jniProxyAssemblyBuilder.DefineDynamicModule("jniproxy.dll");
-#endif
         }
+
 #endif
 
-        internal sealed override ModuleBuilder ModuleBuilder
-        {
-            get
-            {
-                return moduleBuilder;
-            }
-        }
+        internal sealed override ModuleBuilder ModuleBuilder => moduleBuilder;
 
         [System.Security.SecuritySafeCritical]
         internal static DynamicClassLoader Get(ClassLoaderWrapper loader)
@@ -476,6 +464,7 @@ namespace IKVM.Internal
 
         sealed class ForgedKeyPair : StrongNameKeyPair
         {
+
             internal static readonly StrongNameKeyPair Instance;
 
             static ForgedKeyPair()
@@ -503,6 +492,7 @@ namespace IKVM.Internal
                 }
                 catch
                 {
+
                 }
             }
 
@@ -529,14 +519,7 @@ namespace IKVM.Internal
         private static ModuleBuilder CreateModuleBuilder()
         {
             AssemblyName name = new AssemblyName();
-            if (JVM.IsSaveDebugImage)
-            {
-                name.Name = "ikvmdump-" + System.Threading.Interlocked.Increment(ref dumpCounter);
-            }
-            else
-            {
-                name.Name = "ikvm_dynamic_assembly__" + (uint)Environment.TickCount;
-            }
+            name.Name = "ikvm_dynamic_assembly__" + (uint)Environment.TickCount;
             return CreateModuleBuilder(name);
         }
 
@@ -553,10 +536,8 @@ namespace IKVM.Internal
 #endif
 
 #if NETFRAMEWORK
-
             if (!AppDomain.CurrentDomain.IsFullyTrusted)
                 attribs.Add(new CustomAttributeBuilder(typeof(System.Security.SecurityTransparentAttribute).GetConstructor(Type.EmptyTypes), new object[0]));
-
 #endif
 
             AssemblyBuilder assemblyBuilder = DefineDynamicAssembly(name, access, attribs);

--- a/src/IKVM.Runtime/DynamicTypeWrapper.cs
+++ b/src/IKVM.Runtime/DynamicTypeWrapper.cs
@@ -1465,12 +1465,7 @@ namespace IKVM.Internal
 #if STATIC_COMPILER
 						StaticCompiler.LinkageError("Method \"{2}.{3}{4}\" has a return type \"{0}\" and tries to override method \"{5}.{3}{4}\" that has a return type \"{1}\"", mw.ReturnType, baseMethod.ReturnType, mw.DeclaringType.Name, mw.Name, mw.Signature, baseMethod.DeclaringType.Name);
 #else
-                        // when we're finishing types to save a debug image (in dynamic mode) we don't care about loader constraints anymore
-                        // (and we can't throw a LinkageError, because that would prevent the debug image from being saved)
-                        if (!JVM.FinishingForDebugSave)
-                        {
-                            throw new LinkageError("Loader constraints violated");
-                        }
+                        throw new LinkageError("Loader constraints violated");
 #endif
                     }
                 }
@@ -1493,12 +1488,7 @@ namespace IKVM.Internal
 #if STATIC_COMPILER
 							StaticCompiler.LinkageError("Method \"{2}.{3}{4}\" has an argument type \"{0}\" and tries to override method \"{5}.{3}{4}\" that has an argument type \"{1}\"", here[i], there[i], mw.DeclaringType.Name, mw.Name, mw.Signature, baseMethod.DeclaringType.Name);
 #else
-                            // when we're finishing types to save a debug image (in dynamic mode) we don't care about loader constraints anymore
-                            // (and we can't throw a LinkageError, because that would prevent the debug image from being saved)
-                            if (!JVM.FinishingForDebugSave)
-                            {
-                                throw new LinkageError("Loader constraints violated");
-                            }
+                            throw new LinkageError("Loader constraints violated");
 #endif
                         }
                     }
@@ -4516,16 +4506,7 @@ namespace IKVM.Internal
 #endif
                                     else
                                     {
-                                        if (JVM.IsSaveDebugImage)
-                                        {
-#if !STATIC_COMPILER
-                                            JniProxyBuilder.Generate(this, ilGenerator, wrapper, methods[i], typeBuilder, classFile, m, args);
-#endif // !STATIC_COMPILER
-                                        }
-                                        else
-                                        {
-                                            JniBuilder.Generate(this, ilGenerator, wrapper, methods[i], typeBuilder, classFile, m, args, false);
-                                        }
+                                        JniBuilder.Generate(this, ilGenerator, wrapper, methods[i], typeBuilder, classFile, m, args, false);
                                     }
                                 }
                                 ilGenerator.DoEmit();
@@ -5724,6 +5705,7 @@ namespace IKVM.Internal
 #if !STATIC_COMPILER
             internal static class JniProxyBuilder
             {
+
                 private readonly static ModuleBuilder mod;
                 private static int count;
 
@@ -6923,7 +6905,7 @@ namespace IKVM.Internal
             if (mbld != null)
             {
 #if NETFRAMEWORK
-				return mbld.GetToken().Token;
+                return mbld.GetToken().Token;
 #else
                 BindingFlags flags = BindingFlags.DeclaredOnly;
                 flags |= mbld.IsPublic ? BindingFlags.Public : BindingFlags.NonPublic;

--- a/src/IKVM.Runtime/vm.cs
+++ b/src/IKVM.Runtime/vm.cs
@@ -42,16 +42,6 @@ namespace IKVM.Internal
     public static class Starter
     {
 
-        public static void PrepareForSaveDebugImage()
-        {
-            JVM.IsSaveDebugImage = true;
-        }
-
-        public static void SaveDebugImage()
-        {
-            DynamicClassLoader.SaveDebugImages();
-        }
-
         public static bool ClassUnloading
         {
 #if CLASSGC
@@ -91,11 +81,9 @@ namespace IKVM.Internal
 
 #if STATIC_COMPILER
 		internal const bool FinishingForDebugSave = false;
-		internal const bool IsSaveDebugImage = false;
 #elif !STUB_GENERATOR
         private static bool finishingForDebugSave;
         private static int emitSymbols;
-        internal static bool IsSaveDebugImage;
 #if CLASSGC
 		internal static bool classUnloading = true;
 #endif
@@ -109,14 +97,12 @@ namespace IKVM.Internal
 #endif
 
 #if !STATIC_COMPILER && !STUB_GENERATOR && !FIRST_PASS
+
         static JVM()
         {
-            if (SafeGetEnvironmentVariable("IKVM_SAVE_DYNAMIC_ASSEMBLIES") != null)
-            {
-                IsSaveDebugImage = true;
-                java.lang.Runtime.getRuntime().addShutdownHook(new java.lang.Thread(ikvm.runtime.Delegates.toRunnable(DynamicClassLoader.SaveDebugImages)));
-            }
+
         }
+
 #endif
 
         internal static Version SafeGetAssemblyVersion(System.Reflection.Assembly asm)
@@ -172,17 +158,6 @@ namespace IKVM.Internal
         }
 
 #if !STATIC_COMPILER && !STUB_GENERATOR
-        internal static bool FinishingForDebugSave
-        {
-            get
-            {
-                return finishingForDebugSave;
-            }
-            set
-            {
-                finishingForDebugSave = value;
-            }
-        }
 
         internal static bool EmitSymbols
         {

--- a/src/ikvm/starter.cs
+++ b/src/ikvm/starter.cs
@@ -31,218 +31,180 @@ using java.lang.reflect;
 
 public static class Starter
 {
-	private class Timer
-	{
-		private static Timer t;
-		private DateTime now = DateTime.Now;
+    private class Timer
+    {
+        private static Timer t;
+        private DateTime now = DateTime.Now;
 
-		internal Timer()
-		{
-			t = this;
-		}
+        internal Timer()
+        {
+            t = this;
+        }
 
-		~Timer()
-		{
-			Console.WriteLine(DateTime.Now - now);
-		}
-	}
+        ~Timer()
+        {
+            Console.WriteLine(DateTime.Now - now);
+        }
+    }
 
-	private class SaveAssemblyShutdownHook : java.lang.Thread
-	{
-		private java.lang.Class clazz;
+    private class WaitShutdownHook : java.lang.Thread
+    {
+        internal WaitShutdownHook()
+            : base("WaitShutdownHook")
+        {
+        }
 
-		internal SaveAssemblyShutdownHook(java.lang.Class clazz)
-			: base("SaveAssemblyShutdownHook")
-		{
-			this.clazz = clazz;
-		}
+        public override void run()
+        {
+            Console.Error.WriteLine("IKVM runtime terminated. Waiting for Ctrl+C...");
+            for (; ; )
+            {
+                System.Threading.Thread.Sleep(System.Threading.Timeout.Infinite);
+            }
+        }
+    }
 
-		public override void run()
-		{
-			System.Threading.Thread.CurrentThread.Priority = System.Threading.ThreadPriority.AboveNormal;
-			try
-			{
-				IKVM.Internal.Starter.SaveDebugImage();
-			}
-			catch(Exception x)
-			{
-				Console.Error.WriteLine(x);
-				Console.Error.WriteLine(new System.Diagnostics.StackTrace(x, true));
-				System.Diagnostics.Debug.Assert(false, x.ToString());
-			}
-		}
-	}
-
-	private class WaitShutdownHook : java.lang.Thread
-	{
-		internal WaitShutdownHook()
-			: base("WaitShutdownHook")
-		{
-		}
-
-		public override void run()
-		{
-			Console.Error.WriteLine("IKVM runtime terminated. Waiting for Ctrl+C...");
-			for(;;)
-			{
-				System.Threading.Thread.Sleep(System.Threading.Timeout.Infinite);
-			}
-		}
-	}
-
-	[STAThread]	// NOTE this is here because otherwise SWT's RegisterDragDrop (a COM thing) doesn't work
-	[IKVM.Attributes.HideFromJava]
-	static int Main(string[] args)
-	{
-		Tracer.EnableTraceConsoleListener();
-		Tracer.EnableTraceForDebug();
-		System.Collections.Hashtable props = new System.Collections.Hashtable();
-		string classpath = Environment.GetEnvironmentVariable("CLASSPATH");
-		if(classpath == null || classpath == "")
-		{
-			classpath = ".";
-		}
-		props["java.class.path"] = classpath;
-		bool jar = false;
-		bool saveAssembly = false;
-		bool saveAssemblyX = false;
-		bool waitOnExit = false;
-		bool showVersion = false;
-		string mainClass = null;
-		int vmargsIndex = -1;
+    [STAThread] // NOTE this is here because otherwise SWT's RegisterDragDrop (a COM thing) doesn't work
+    [IKVM.Attributes.HideFromJava]
+    static int Main(string[] args)
+    {
+        Tracer.EnableTraceConsoleListener();
+        Tracer.EnableTraceForDebug();
+        System.Collections.Hashtable props = new System.Collections.Hashtable();
+        string classpath = Environment.GetEnvironmentVariable("CLASSPATH");
+        if (classpath == null || classpath == "")
+        {
+            classpath = ".";
+        }
+        props["java.class.path"] = classpath;
+        bool jar = false;
+        bool waitOnExit = false;
+        bool showVersion = false;
+        string mainClass = null;
+        int vmargsIndex = -1;
         bool debug = false;
         String debugArg = null;
-		bool noglobbing = false;
-		for(int i = 0; i < args.Length; i++)
-		{
+        bool noglobbing = false;
+        for (int i = 0; i < args.Length; i++)
+        {
             String arg = args[i];
-			if(arg[0] == '-')
-			{
-				if(arg == "-help" || arg == "-?")
-				{
-					PrintHelp();
-					return 1;
-				}
-				else if(arg == "-X")
-				{
-					PrintXHelp();
-					return 1;
-				}
-				else if(arg == "-Xsave")
-				{
-					saveAssembly = true;
-					IKVM.Internal.Starter.PrepareForSaveDebugImage();
-				}
-				else if(arg == "-XXsave")
-				{
-					saveAssemblyX = true;
-					IKVM.Internal.Starter.PrepareForSaveDebugImage();
-				}
-				else if(arg == "-Xtime")
-				{
-					new Timer();
-				}
-				else if(arg == "-Xwait")
-				{
-					waitOnExit = true;
-				}
-				else if(arg == "-Xbreak")
-				{
-					System.Diagnostics.Debugger.Break();
-				}
-				else if(arg == "-Xnoclassgc")
-				{
-					IKVM.Internal.Starter.ClassUnloading = false;
-				}
-				else if(arg == "-Xverify")
-				{
-					IKVM.Internal.Starter.RelaxedVerification = false;
-				}
-				else if(arg == "-jar")
-				{
-					jar = true;
-				}
-				else if(arg == "-version")
-				{
-					Console.WriteLine(Startup.getVersionAndCopyrightInfo());
-					Console.WriteLine();
-					Console.WriteLine("CLR version: {0} ({1} bit)", Environment.Version, IntPtr.Size * 8);
-					System.Type type = System.Type.GetType("Mono.Runtime");
-					if(type != null)
-					{
-						Console.WriteLine("Mono version: {0}", type.InvokeMember("GetDisplayName", BindingFlags.InvokeMethod | BindingFlags.Static | BindingFlags.NonPublic, null, null, new object[0]));
-					}
-					foreach(Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
-					{
-						Console.WriteLine("{0}: {1}", asm.GetName().Name, asm.GetName().Version);
-					}
-					string ver = java.lang.System.getProperty("openjdk.version");
-					if(ver != null)
-					{
-						Console.WriteLine("OpenJDK version: {0}", ver);
-					}
-					return 0;
-				}
-				else if(arg == "-showversion")
-				{
-					showVersion = true;
-				}
-				else if(arg.StartsWith("-D"))
-				{
-				    arg = arg.Substring(2);
+            if (arg[0] == '-')
+            {
+                if (arg == "-help" || arg == "-?")
+                {
+                    PrintHelp();
+                    return 1;
+                }
+                else if (arg == "-X")
+                {
+                    PrintXHelp();
+                    return 1;
+                }
+                else if (arg == "-Xtime")
+                {
+                    new Timer();
+                }
+                else if (arg == "-Xwait")
+                {
+                    waitOnExit = true;
+                }
+                else if (arg == "-Xbreak")
+                {
+                    System.Diagnostics.Debugger.Break();
+                }
+                else if (arg == "-Xnoclassgc")
+                {
+                    IKVM.Internal.Starter.ClassUnloading = false;
+                }
+                else if (arg == "-Xverify")
+                {
+                    IKVM.Internal.Starter.RelaxedVerification = false;
+                }
+                else if (arg == "-jar")
+                {
+                    jar = true;
+                }
+                else if (arg == "-version")
+                {
+                    Console.WriteLine(Startup.getVersionAndCopyrightInfo());
+                    Console.WriteLine();
+                    Console.WriteLine("CLR version: {0} ({1} bit)", Environment.Version, IntPtr.Size * 8);
+                    System.Type type = System.Type.GetType("Mono.Runtime");
+                    if (type != null)
+                    {
+                        Console.WriteLine("Mono version: {0}", type.InvokeMember("GetDisplayName", BindingFlags.InvokeMethod | BindingFlags.Static | BindingFlags.NonPublic, null, null, new object[0]));
+                    }
+                    foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+                    {
+                        Console.WriteLine("{0}: {1}", asm.GetName().Name, asm.GetName().Version);
+                    }
+                    string ver = java.lang.System.getProperty("openjdk.version");
+                    if (ver != null)
+                    {
+                        Console.WriteLine("OpenJDK version: {0}", ver);
+                    }
+                    return 0;
+                }
+                else if (arg == "-showversion")
+                {
+                    showVersion = true;
+                }
+                else if (arg.StartsWith("-D"))
+                {
+                    arg = arg.Substring(2);
                     string[] keyvalue = arg.Split('=');
-				    string value;
-					if(keyvalue.Length == 2) // -Dabc=x
-					{
+                    string value;
+                    if (keyvalue.Length == 2) // -Dabc=x
+                    {
                         value = keyvalue[1];
-					} 
+                    }
                     else if (keyvalue.Length == 1) // -Dabc
                     {
                         value = "";
-                    } 
+                    }
                     else // -Dabc=x=y
-					{
+                    {
                         value = arg.Substring(keyvalue[0].Length + 1);
-					}
+                    }
                     props[keyvalue[0]] = value;
-				}
-				else if(arg == "-ea" || arg == "-enableassertions")
-				{
-					IKVM.Runtime.Assertions.EnableAssertions();
-				}
-				else if(arg == "-da" || arg == "-disableassertions")
-				{
-					IKVM.Runtime.Assertions.DisableAssertions();
-				}
-				else if(arg == "-esa" || arg == "-enablesystemassertions")
-				{
-					IKVM.Runtime.Assertions.EnableSystemAssertions();
-				}
-				else if(arg == "-dsa" || arg == "-disablesystemassertions")
-				{
-					IKVM.Runtime.Assertions.DisableSystemAssertions();
-				}
-				else if(arg.StartsWith("-ea:") || arg.StartsWith("-enableassertions:"))
-				{
-					IKVM.Runtime.Assertions.EnableAssertions(arg.Substring(arg.IndexOf(':') + 1));
-				}
-				else if(arg.StartsWith("-da:") || arg.StartsWith("-disableassertions:"))
-				{
-					IKVM.Runtime.Assertions.DisableAssertions(arg.Substring(arg.IndexOf(':') + 1));
-				}
-				else if(arg == "-cp" || arg == "-classpath")
-				{
-					props["java.class.path"] = args[++i];
-				}
-				else if(arg.StartsWith("-Xtrace:"))
-				{
-					Tracer.SetTraceLevel(arg.Substring(8));
-				}
-				else if(arg.StartsWith("-Xmethodtrace:"))
-				{
-					Tracer.HandleMethodTrace(arg.Substring(14));
-				}
-                else if(arg == "-Xdebug")
+                }
+                else if (arg == "-ea" || arg == "-enableassertions")
+                {
+                    IKVM.Runtime.Assertions.EnableAssertions();
+                }
+                else if (arg == "-da" || arg == "-disableassertions")
+                {
+                    IKVM.Runtime.Assertions.DisableAssertions();
+                }
+                else if (arg == "-esa" || arg == "-enablesystemassertions")
+                {
+                    IKVM.Runtime.Assertions.EnableSystemAssertions();
+                }
+                else if (arg == "-dsa" || arg == "-disablesystemassertions")
+                {
+                    IKVM.Runtime.Assertions.DisableSystemAssertions();
+                }
+                else if (arg.StartsWith("-ea:") || arg.StartsWith("-enableassertions:"))
+                {
+                    IKVM.Runtime.Assertions.EnableAssertions(arg.Substring(arg.IndexOf(':') + 1));
+                }
+                else if (arg.StartsWith("-da:") || arg.StartsWith("-disableassertions:"))
+                {
+                    IKVM.Runtime.Assertions.DisableAssertions(arg.Substring(arg.IndexOf(':') + 1));
+                }
+                else if (arg == "-cp" || arg == "-classpath")
+                {
+                    props["java.class.path"] = args[++i];
+                }
+                else if (arg.StartsWith("-Xtrace:"))
+                {
+                    Tracer.SetTraceLevel(arg.Substring(8));
+                }
+                else if (arg.StartsWith("-Xmethodtrace:"))
+                {
+                    Tracer.HandleMethodTrace(arg.Substring(14));
+                }
+                else if (arg == "-Xdebug")
                 {
                     debug = true;
                 }
@@ -291,26 +253,26 @@ public static class Starter
                     Console.Error.WriteLine("{0}: illegal argument", arg);
                     break;
                 }
-			}
-			else
-			{
-				mainClass = arg;
-				vmargsIndex = i + 1;
-				break;
-			}
-		}
-		if(mainClass == null || showVersion)
-		{
-			Console.Error.WriteLine(Startup.getVersionAndCopyrightInfo());
-			Console.Error.WriteLine();
-		}
-		if(mainClass == null)
-		{
-			PrintHelp();
-			return 1;
-		}
-		try
-		{
+            }
+            else
+            {
+                mainClass = arg;
+                vmargsIndex = i + 1;
+                break;
+            }
+        }
+        if (mainClass == null || showVersion)
+        {
+            Console.Error.WriteLine(Startup.getVersionAndCopyrightInfo());
+            Console.Error.WriteLine();
+        }
+        if (mainClass == null)
+        {
+            PrintHelp();
+            return 1;
+        }
+        try
+        {
             if (debug)
             {
                 // Starting the debugger
@@ -331,108 +293,96 @@ public static class Starter
                     throw ex;
                 }
             }
-			if(jar)
-			{
-				props["java.class.path"] = mainClass;
-			}
-			// like the JDK we don't quote the args (even if they contain spaces)
-			props["sun.java.command"] = String.Join(" ", args, vmargsIndex - 1, args.Length - (vmargsIndex - 1));
-			props["sun.java.launcher"] = "SUN_STANDARD";
-			Startup.setProperties(props);
-			Startup.enterMainThread();
-			string[] vmargs;
-			if (noglobbing)
-			{
-				vmargs = new string[args.Length - vmargsIndex];
-				System.Array.Copy(args, vmargsIndex, vmargs, 0, vmargs.Length);
-			}
-			else
-			{
-				// Startup.glob() uses Java code, so we need to do this after we've initialized
-				vmargs = Startup.glob(args, vmargsIndex);
-			}
-			try
-			{
-				java.lang.Class clazz = sun.launcher.LauncherHelper.checkAndLoadMain(true, jar ? 2 : 1, mainClass);
-				// we don't need to do any checking on the main method, as that was already done by checkAndLoadMain
-				Method method = clazz.getMethod("main", typeof(string[]));
-				// if clazz isn't public, we can still call main
-				method.setAccessible(true);
-				if(saveAssembly)
-				{
-					java.lang.Runtime.getRuntime().addShutdownHook(new SaveAssemblyShutdownHook(clazz));
-				}
-				if(waitOnExit)
-				{
-					java.lang.Runtime.getRuntime().addShutdownHook(new WaitShutdownHook());
-				}
-				try
-				{
-					method.invoke(null, new object[] { vmargs });
-					return 0;
-				}
-				catch(InvocationTargetException x)
-				{
-					throw x.getCause();
-				}
-			}
-			finally
-			{
-				if(saveAssemblyX)
-				{
-					IKVM.Internal.Starter.SaveDebugImage();
-				}
-			}
-		}
-		catch(System.Exception x)
-		{
-			java.lang.Thread thread = java.lang.Thread.currentThread();
-			thread.getThreadGroup().uncaughtException(thread, ikvm.runtime.Util.mapException(x));
-		}
-		finally
-		{
-			Startup.exitMainThread();
-		}
-		return 1;
-	}
+            if (jar)
+            {
+                props["java.class.path"] = mainClass;
+            }
+            // like the JDK we don't quote the args (even if they contain spaces)
+            props["sun.java.command"] = String.Join(" ", args, vmargsIndex - 1, args.Length - (vmargsIndex - 1));
+            props["sun.java.launcher"] = "SUN_STANDARD";
+            Startup.setProperties(props);
+            Startup.enterMainThread();
+            string[] vmargs;
+            if (noglobbing)
+            {
+                vmargs = new string[args.Length - vmargsIndex];
+                System.Array.Copy(args, vmargsIndex, vmargs, 0, vmargs.Length);
+            }
+            else
+            {
+                // Startup.glob() uses Java code, so we need to do this after we've initialized
+                vmargs = Startup.glob(args, vmargsIndex);
+            }
 
-	private static void PrintHelp()
-	{
-		Console.Error.WriteLine("usage: ikvm [-options] <class> [args...]");
-		Console.Error.WriteLine("          (to execute a class)");
-		Console.Error.WriteLine("    or ikvm -jar [-options] <jarfile> [args...]");
-		Console.Error.WriteLine("          (to execute a jar file)");
-		Console.Error.WriteLine();
-		Console.Error.WriteLine("where options include:");
-		Console.Error.WriteLine("    -? -help          Display this message");
-		Console.Error.WriteLine("    -X                Display non-standard options");
-		Console.Error.WriteLine("    -version          Display IKVM and runtime version");
-		Console.Error.WriteLine("    -showversion      Display version and continue running");
-		Console.Error.WriteLine("    -cp -classpath <directories and zip/jar files separated by {0}>", Path.PathSeparator);
-		Console.Error.WriteLine("                      Set search path for application classes and resources");
-		Console.Error.WriteLine("    -D<name>=<value>  Set a system property");
-		Console.Error.WriteLine("    -ea[:<packagename>...|:<classname>]");
-		Console.Error.WriteLine("    -enableassertions[:<packagename>...|:<classname>]");
-		Console.Error.WriteLine("                      Enable assertions.");
-		Console.Error.WriteLine("    -da[:<packagename>...|:<classname>]");
-		Console.Error.WriteLine("    -disableassertions[:<packagename>...|:<classname>]");
-		Console.Error.WriteLine("                      Disable assertions");
-	}
+            java.lang.Class clazz = sun.launcher.LauncherHelper.checkAndLoadMain(true, jar ? 2 : 1, mainClass);
+            // we don't need to do any checking on the main method, as that was already done by checkAndLoadMain
+            Method method = clazz.getMethod("main", typeof(string[]));
+            // if clazz isn't public, we can still call main
+            method.setAccessible(true);
+            if (waitOnExit)
+            {
+                java.lang.Runtime.getRuntime().addShutdownHook(new WaitShutdownHook());
+            }
+            try
+            {
+                method.invoke(null, new object[] { vmargs });
+                return 0;
+            }
+            catch (InvocationTargetException x)
+            {
+                throw x.getCause();
+            }
+        }
+        catch (System.Exception x)
+        {
+            java.lang.Thread thread = java.lang.Thread.currentThread();
+            thread.getThreadGroup().uncaughtException(thread, ikvm.runtime.Util.mapException(x));
+        }
+        finally
+        {
+            Startup.exitMainThread();
+        }
 
-	private static void PrintXHelp()
-	{
-		Console.Error.WriteLine("    -Xsave            Save the generated assembly (for troubleshooting)");
-		Console.Error.WriteLine("    -Xtime            Time the execution");
-		Console.Error.WriteLine("    -Xtrace:<string>  Displays all tracepoints with the given name");
-		Console.Error.WriteLine("    -Xmethodtrace:<string>");
-		Console.Error.WriteLine("                      Builds method trace into the specified output methods");
-		Console.Error.WriteLine("    -Xwait            Keep process hanging around after exit");
-		Console.Error.WriteLine("    -Xbreak           Trigger a user defined breakpoint at startup");
-		Console.Error.WriteLine("    -Xnoclassgc       Disable class garbage collection");
-		Console.Error.WriteLine("    -Xnoglobbing      Disable argument globbing");
-		Console.Error.WriteLine("    -Xverify          Enable strict class file verification");
-		Console.Error.WriteLine();
-		Console.Error.WriteLine("The -X options are non-standard and subject to change without notice.");
-		Console.Error.WriteLine();
-	}
+        return 1;
+    }
+
+    private static void PrintHelp()
+    {
+        Console.Error.WriteLine("usage: ikvm [-options] <class> [args...]");
+        Console.Error.WriteLine("          (to execute a class)");
+        Console.Error.WriteLine("    or ikvm -jar [-options] <jarfile> [args...]");
+        Console.Error.WriteLine("          (to execute a jar file)");
+        Console.Error.WriteLine();
+        Console.Error.WriteLine("where options include:");
+        Console.Error.WriteLine("    -? -help          Display this message");
+        Console.Error.WriteLine("    -X                Display non-standard options");
+        Console.Error.WriteLine("    -version          Display IKVM and runtime version");
+        Console.Error.WriteLine("    -showversion      Display version and continue running");
+        Console.Error.WriteLine("    -cp -classpath <directories and zip/jar files separated by {0}>", Path.PathSeparator);
+        Console.Error.WriteLine("                      Set search path for application classes and resources");
+        Console.Error.WriteLine("    -D<name>=<value>  Set a system property");
+        Console.Error.WriteLine("    -ea[:<packagename>...|:<classname>]");
+        Console.Error.WriteLine("    -enableassertions[:<packagename>...|:<classname>]");
+        Console.Error.WriteLine("                      Enable assertions.");
+        Console.Error.WriteLine("    -da[:<packagename>...|:<classname>]");
+        Console.Error.WriteLine("    -disableassertions[:<packagename>...|:<classname>]");
+        Console.Error.WriteLine("                      Disable assertions");
+    }
+
+    static void PrintXHelp()
+    {
+        Console.Error.WriteLine("    -Xtime            Time the execution");
+        Console.Error.WriteLine("    -Xtrace:<string>  Displays all tracepoints with the given name");
+        Console.Error.WriteLine("    -Xmethodtrace:<string>");
+        Console.Error.WriteLine("                      Builds method trace into the specified output methods");
+        Console.Error.WriteLine("    -Xwait            Keep process hanging around after exit");
+        Console.Error.WriteLine("    -Xbreak           Trigger a user defined breakpoint at startup");
+        Console.Error.WriteLine("    -Xnoclassgc       Disable class garbage collection");
+        Console.Error.WriteLine("    -Xnoglobbing      Disable argument globbing");
+        Console.Error.WriteLine("    -Xverify          Enable strict class file verification");
+        Console.Error.WriteLine();
+        Console.Error.WriteLine("The -X options are non-standard and subject to change without notice.");
+        Console.Error.WriteLine();
+    }
+
 }


### PR DESCRIPTION
Feature is impossible to reimplement on Core given the current state of things. I don't think we should have big features like this which have no future path forwards.

It might make a return some day when we replace System.Reflection.Emit. But that's going to be far down the road, and whatever end up is going to be very different.