### PR TITLE
Copy response and log files for compiler to cache directory

### DIFF
--- a/src/IKVM.MSBuild.Tasks/IkvmReferenceItemPrepare.cs
+++ b/src/IKVM.MSBuild.Tasks/IkvmReferenceItemPrepare.cs
@@ -7,6 +7,7 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.RegularExpressions;
 
 using IKVM.Util.Jar;
 using IKVM.Util.Modules;
@@ -457,13 +458,13 @@ namespace IKVM.MSBuild.Tasks
             var sha1File = file + ".sha1";
             if (File.Exists(sha1File))
                 if (File.ReadAllText(sha1File) is string h)
-                    return h.Trim();
+                    return $"SHA1:{Regex.Match(h.Trim(), @"^([\w\-]+)").Value}";
 
             // file might have a companion MD5 hash, let's use it, no calculation required
             var md5File = file + ".md5";
             if (File.Exists(md5File))
                 if (File.ReadAllText(md5File) is string h)
-                    return h.Trim();
+                    return $"MD5:{Regex.Match(h.Trim(), @"^([\w\-]+)").Value}";
 
             // if the file is potentially a .NET assembly
             if (Path.GetExtension(file) == ".dll" || Path.GetExtension(file) == ".exe")

--- a/src/IKVM.MSBuild.Tasks/IkvmToolExecTask.cs
+++ b/src/IKVM.MSBuild.Tasks/IkvmToolExecTask.cs
@@ -44,6 +44,11 @@ namespace IKVM.MSBuild.Tasks
         public string ToolFramework { get; set; } = "NetCore";
 
         /// <summary>
+        /// Optional path to a log file to copy messages to.
+        /// </summary>
+        public string LogFile { get; set; }
+
+        /// <summary>
         /// Number of milliseconds to wait for the command to execute.
         /// </summary>
         public int Timeout { get; set; } = System.Threading.Timeout.Infinite;
@@ -66,16 +71,33 @@ namespace IKVM.MSBuild.Tasks
             if (ToolPath == null || Directory.Exists(ToolPath) == false)
                 throw new IkvmTaskException($"Missing tool path: '{ToolPath}'.");
 
-            // kick off the launcher with the configured options
-            var run = System.Threading.Tasks.Task.Run(() => ExecuteAsync(toolFramework, new IkvmToolTaskDiagnosticWriter(Log), CancellationToken.None));
+            TextWriter log = null;
 
-            // yield and wait for the task to complete
-            BuildEngine3.Yield();
-            var rsl = run.GetAwaiter().GetResult();
-            BuildEngine3.Reacquire();
+            try
+            {
+                // optionally copy output to a text file
+                if (LogFile != null)
+                    log = new StreamWriter(File.OpenWrite(LogFile));
 
-            // check that we exited successfully
-            return rsl;
+                // kick off the launcher with the configured options
+                var run = System.Threading.Tasks.Task.Run(() => ExecuteAsync(toolFramework, new IkvmToolTaskDiagnosticWriter(Log, log), CancellationToken.None));
+
+                // yield and wait for the task to complete
+                BuildEngine3.Yield();
+                var rsl = run.GetAwaiter().GetResult();
+                BuildEngine3.Reacquire();
+
+                // check that we exited successfully
+                return rsl;
+            }
+            finally
+            {
+                if (log != null)
+                {
+                    log.Dispose();
+                    log = null;
+                }
+            }
         }
 
         /// <summary>

--- a/src/IKVM.MSBuild.Tasks/IkvmToolTaskDiagnosticWriter.cs
+++ b/src/IKVM.MSBuild.Tasks/IkvmToolTaskDiagnosticWriter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 
 using IKVM.Tools.Runner;
@@ -12,16 +13,19 @@ namespace IKVM.MSBuild.Tasks
     public class IkvmToolTaskDiagnosticWriter : IIkvmToolDiagnosticEventListener
     {
 
-        readonly Microsoft.Build.Utilities.TaskLoggingHelper log;
+        readonly Microsoft.Build.Utilities.TaskLoggingHelper logger;
+        readonly TextWriter writer;
 
         /// <summary>
         /// Initializes a new instance.
         /// </summary>
-        /// <param name="log"></param>
+        /// <param name="logger"></param>
+        /// <param name="writer"></param>
         /// <exception cref="ArgumentNullException"></exception>
-        public IkvmToolTaskDiagnosticWriter(Microsoft.Build.Utilities.TaskLoggingHelper log)
+        public IkvmToolTaskDiagnosticWriter(Microsoft.Build.Utilities.TaskLoggingHelper logger, TextWriter writer)
         {
-            this.log = log ?? throw new ArgumentNullException(nameof(log));
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+            this.writer = writer;
         }
 
         /// <summary>
@@ -34,16 +38,24 @@ namespace IKVM.MSBuild.Tasks
             switch (@event.Level)
             {
                 case IkvmToolDiagnosticEventLevel.Debug:
-                    log.LogMessage(Microsoft.Build.Framework.MessageImportance.Low, @event.Message, @event.MessageArgs);
+                    logger.LogMessage(Microsoft.Build.Framework.MessageImportance.Low, @event.Message, @event.MessageArgs);
+                    if (writer != null)
+                        writer.WriteLine("DEBUG: " + @event.Message, @event.MessageArgs);
                     break;
                 case IkvmToolDiagnosticEventLevel.Information:
-                    log.LogMessage(Microsoft.Build.Framework.MessageImportance.Normal, @event.Message, @event.MessageArgs);
+                    logger.LogMessage(Microsoft.Build.Framework.MessageImportance.Normal, @event.Message, @event.MessageArgs);
+                    if (writer != null)
+                        writer.WriteLine("INFO: " + @event.Message, @event.MessageArgs);
                     break;
                 case IkvmToolDiagnosticEventLevel.Warning:
-                    log.LogWarning(@event.Message, @event.MessageArgs);
+                    logger.LogWarning(@event.Message, @event.MessageArgs);
+                    if (writer != null)
+                        writer.WriteLine("WARN: " + @event.Message, @event.MessageArgs);
                     break;
                 case IkvmToolDiagnosticEventLevel.Error:
-                    log.LogWarning(@event.Message, @event.MessageArgs);
+                    logger.LogWarning(@event.Message, @event.MessageArgs);
+                    if (writer != null)
+                        writer.WriteLine("ERROR: " + @event.Message, @event.MessageArgs);
                     break;
             }
 

--- a/src/IKVM/buildTransitive/netstandard2.0/IKVM.Tasks.targets
+++ b/src/IKVM/buildTransitive/netstandard2.0/IKVM.Tasks.targets
@@ -82,6 +82,7 @@
         <ItemGroup>
             <FileWrites Include="%(IkvmReferenceItem.StagePath)" />
             <FileWrites Include="%(IkvmReferenceItem.StagePath).rsp" />
+            <FileWrites Include="%(IkvmReferenceItem.StagePath).log" />
         </ItemGroup>
     </Target>
 

--- a/src/IKVM/buildTransitive/netstandard2.0/IKVM.Tasks.targets
+++ b/src/IKVM/buildTransitive/netstandard2.0/IKVM.Tasks.targets
@@ -33,6 +33,7 @@
         <IkvmCompiler
             ToolPath="$(IkvmCompilerToolPath)"
             ToolFramework="$(IkvmToolFramework)"
+            LogFile="%(IkvmReferenceItem.StagePath).log"
             ResponseFile="%(IkvmReferenceItem.StagePath).rsp"
             Output="%(IkvmReferenceItem.StagePath)"
             Assembly="%(IkvmReferenceItem.AssemblyName)"
@@ -63,6 +64,20 @@
             DestinationFiles="%(IkvmReferenceItem.CacheSymbolsPath)"
             OverwriteReadOnlyFiles="true"
             Condition="Exists('%(IkvmReferenceItem.StageSymbolsPath)')"/>
+
+        <!-- Copy the response file to the cache path. -->
+        <Copy
+            SourceFiles="%(IkvmReferenceItem.StagePath).rsp"
+            DestinationFiles="%(IkvmReferenceItem.CachePath).rsp"
+            OverwriteReadOnlyFiles="true"
+            Condition="Exists('%(IkvmReferenceItem.StagePath).rsp')"/>
+
+        <!-- Copy the log file to the cache path. -->
+        <Copy
+            SourceFiles="%(IkvmReferenceItem.StagePath).log"
+            DestinationFiles="%(IkvmReferenceItem.CachePath).log"
+            OverwriteReadOnlyFiles="true"
+            Condition="Exists('%(IkvmReferenceItem.StagePath).log')"/>
 
         <ItemGroup>
             <FileWrites Include="%(IkvmReferenceItem.StagePath)" />


### PR DESCRIPTION
Will allow the user to review what went into generating a cached assembly.