### PR TITLE
Use System.Text.Json instead of Newtonsoft.Json

### DIFF
--- a/src/IKVM.Tests/IKVM.Tests.csproj
+++ b/src/IKVM.Tests/IKVM.Tests.csproj
@@ -35,7 +35,6 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
         <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/IKVM.Tests/Java/java/net/URLTests.cs
+++ b/src/IKVM.Tests/Java/java/net/URLTests.cs
@@ -20,7 +20,7 @@ namespace IKVM.Tests.Java.java.net
             var bytesRead = stm.read(buf, 0, 8192);
             var str = Encoding.UTF8.GetString(buf, 0, bytesRead);
             var json = JsonNode.Parse(str);
-            json["args"]["text"].As<string>().Should().Be("ECHO");
+            json["args"]["text"].GetValue<string>().Should().Be("ECHO");
         }
 
     }

--- a/src/IKVM.Tests/Java/java/net/URLTests.cs
+++ b/src/IKVM.Tests/Java/java/net/URLTests.cs
@@ -1,10 +1,9 @@
 ﻿using System.Text;
-
 using FluentAssertions;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-using Newtonsoft.Json.Linq;
+using System.Text.Json.Nodes;
 
 namespace IKVM.Tests.Java.java.net
 {
@@ -20,8 +19,8 @@ namespace IKVM.Tests.Java.java.net
             var buf = new byte[8192];
             var bytesRead = stm.read(buf, 0, 8192);
             var str = Encoding.UTF8.GetString(buf, 0, bytesRead);
-            var json = JObject.Parse(str);
-            json["args"]["text"].Value<string>().Should().Be("ECHO");
+            var json = JsonNode.Parse(str);
+            json["args"]["text"].As<string>().Should().Be("ECHO");
         }
 
     }

--- a/src/IKVM.Tools.Exporter/IKVM.Tools.Exporter.csproj
+++ b/src/IKVM.Tools.Exporter/IKVM.Tools.Exporter.csproj
@@ -7,7 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
 

--- a/src/IKVM.Tools.Exporter/IkvmExporterContext.NetCore.cs
+++ b/src/IKVM.Tools.Exporter/IkvmExporterContext.NetCore.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 using Microsoft.Extensions.DependencyModel.Resolution;
 
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace IKVM.Tools.Exporter
 {
@@ -36,7 +36,7 @@ namespace IKVM.Tools.Exporter
                 if (options is null)
                     throw new ArgumentNullException(nameof(options));
 
-                this.options = JsonConvert.DeserializeObject<IkvmExporterOptions>(options);
+                this.options = JsonSerializer.Deserialize<IkvmExporterOptions>(options);
             }
 
             /// <summary>
@@ -87,7 +87,7 @@ namespace IKVM.Tools.Exporter
             context = new IsolatedAssemblyLoadContext("IkvmExporter", true);
             var asm = context.LoadFromAssemblyName(typeof(IkvmExporterDispatcher).Assembly.GetName());
             var typ = asm.GetType(typeof(IkvmExporterDispatcher).FullName);
-            dispatcher = Activator.CreateInstance(typ, new[] { JsonConvert.SerializeObject(options) });
+            dispatcher = Activator.CreateInstance(typ, new[] { JsonSerializer.Serialize(options) });
         }
 
         /// <summary>

--- a/src/IKVM.Tools.Importer/IKVM.Tools.Importer.csproj
+++ b/src/IKVM.Tools.Importer/IKVM.Tools.Importer.csproj
@@ -13,7 +13,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
 

--- a/src/IKVM.Tools.Importer/IkvmImporterContext.NetCore.cs
+++ b/src/IKVM.Tools.Importer/IkvmImporterContext.NetCore.cs
@@ -6,7 +6,7 @@ using System.Runtime.Loader;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace IKVM.Tools.Importer
 {
@@ -32,7 +32,7 @@ namespace IKVM.Tools.Importer
                 if (args is null)
                     throw new ArgumentNullException(nameof(args));
 
-                this.args = JsonConvert.DeserializeObject<string[]>(args);
+                this.args = JsonSerializer.Deserialize<string[]>(args);
             }
 
             /// <summary>
@@ -86,7 +86,7 @@ namespace IKVM.Tools.Importer
             context = new IsolatedAssemblyLoadContext("IkvmImporter", true);
             var asm = context.LoadFromAssemblyName(typeof(IkvmImporterDispatcher).Assembly.GetName());
             var typ = asm.GetType(typeof(IkvmImporterDispatcher).FullName);
-            dispatcher = Activator.CreateInstance(typ, new[] { JsonConvert.SerializeObject(args) });
+            dispatcher = Activator.CreateInstance(typ, new[] { JsonSerializer.Serialize(args) });
         }
 
         /// <summary>


### PR DESCRIPTION
Use System.Text.Json instead of Newtonsoft.Json as MS recommended Json processing component.